### PR TITLE
Delayed jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,8 @@ You should now see that change at your remote server's ip address
 ### Screencast
 [How to setup email deliveries](https://public.3.basecamp.com/p/yAGcyJeSVHaW43M7aoHCxu6L)
 
+Screencast update: The Installer now configures a queue to send emails asynchronously. Thus you will not see a 500 error when there is a misconfiguration, as the email is sent asyncronously and the error will be raised in the queue. To see email error logs open the rails console (`cd /home/deploy/consul/ && bin/rails c production`) and search for the last error in the queue `Delayed::Job.last.last_error`)
+
 Update the following file in your production server:
 `/home/deploy/consul/shared/config/environments/production.rb`
 

--- a/roles/queue/tasks/main.yml
+++ b/roles/queue/tasks/main.yml
@@ -4,3 +4,14 @@
     dest: "/home/{{ deploy_user}}/consul/config/initializers/delayed_job_config.rb"
     owner: "{{ deploy_user }}"
     group: wheel
+# ToDO
+# - name: Add DelayedJobs start script (after reboot)
+# add to crontab
+
+#ToDO
+#Remember to update for capistrano
+- name: Start DelayedJobs queue
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV=production bin/delayed_job start"
+  args:
+    executable: /bin/bash
+    chdir: /home/{{ deploy_user }}/{{ app_name }}

--- a/roles/queue/tasks/main.yml
+++ b/roles/queue/tasks/main.yml
@@ -5,7 +5,7 @@
 #ToDO
 #Remember to update for capistrano
 - name: Start DelayedJobs queue
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV=production bin/delayed_job start"
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && RAILS_ENV=production bin/delayed_job restart"
   args:
     executable: /bin/bash
     chdir: /home/{{ deploy_user }}/{{ app_name }}

--- a/roles/queue/tasks/main.yml
+++ b/roles/queue/tasks/main.yml
@@ -1,9 +1,3 @@
-- name: Disable queue with DelayedJobs (for now )
-  template:
-    src: "{{ playbook_dir }}/roles/queue/templates/delayed_job_config.rb"
-    dest: "/home/{{ deploy_user}}/consul/config/initializers/delayed_job_config.rb"
-    owner: "{{ deploy_user }}"
-    group: wheel
 # ToDO
 # - name: Add DelayedJobs start script (after reboot)
 # add to crontab

--- a/roles/queue/templates/delayed_job_config.rb
+++ b/roles/queue/templates/delayed_job_config.rb
@@ -1,1 +1,0 @@
-Delayed::Worker.delay_jobs = false

--- a/roles/specs/tasks/main.yml
+++ b/roles/specs/tasks/main.yml
@@ -45,3 +45,11 @@
         follow_redirects: no
         validate_certs: yes
         status_code: 301
+
+- name: Get running delayed job processes
+  shell: "ps -ef | grep -v grep | grep -w delayed_job | awk '{print $2}'"
+  register: delayed_job_process
+
+- fail:
+    msg: "Delayed Jobs is not running"
+  when: delayed_job_process.stdout == ""


### PR DESCRIPTION
## Context

Sending emails takes a few precious seconds which can slow down the response time for users. To speed things up we can use a queue to send emails asynchronously in the background. The queue is also very useful for long running tasks such as sending newsletters to thousands of users or processing signature sheets.

## Objective

Configure queue using DelayedJobs.

## Notes

We should add an cron script to start the DelayedJob queue after a reboot. For now running a `cap production deploy` will start the queue after a reboot.