### PR TITLE
Setup Capistrano by default

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ before_script:
 script: ansible-playbook consul.yml -i hosts
 env:
   RAILS_ENV: production
+  USER: deploy
 addons:
   hosts:
     - travis.dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ script: ansible-playbook consul.yml -i hosts
 env:
   RAILS_ENV: production
   USER: deploy
+  HOME: /home/deploy
 addons:
   hosts:
     - travis.dev

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ script: ansible-playbook consul.yml -i hosts
 env:
   RAILS_ENV: production
   USER: deploy
-  HOME: /home/deploy
 addons:
   hosts:
     - travis.dev

--- a/README.md
+++ b/README.md
@@ -128,18 +128,6 @@ Create your [fork](https://help.github.com/articles/fork-a-repo/)
 
 Setup locally for your [development environment](https://consul_docs.gitbooks.io/docs/content/en/getting_started/local_installation.html))
 
-Uncomment this line in `app.yml` and rerun the installer
-
-```
-# - capistrano
-```
-
-Run the ansible playbook
-
-```
-sudo ansible-playbook -v consul.yml -i hosts
-```
-
 Download changes from the `capistrano` branch to your fork
 
 ```
@@ -169,7 +157,7 @@ Update your `repo_url` in `deploy.rb`
 set :repo_url, 'https://github.com/your_github_username/consul.git'
 ```
 
-Make a change in a view and push it your fork in Github
+Make a change in a view and push it to your fork in Github
 
 ```
 git add .
@@ -216,7 +204,7 @@ Once you setup your domain, depending on your SMTP provider, you will have to do
 - Update the `server_name` with your domain in `/home/deploy/consul/shared/config/secrets.yml`.
 - Update the `sender_email_address` from the admin section (`remote-server-ip-address/admin/settings`)
 
-If your SMTP provider uses an authentication other than `plain`, check out the [Rails docs on email configuration](https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration) for the different authentation options.
+If your SMTP provider uses an authentication other than `plain`, check out the [Rails docs on email configuration](https://guides.rubyonrails.org/action_mailer_basics.html#action-mailer-configuration) for the different authentication options.
 
 ## Configuration Variables
 

--- a/app.yml
+++ b/app.yml
@@ -8,6 +8,7 @@
   roles:
     - ruby
     - rails
+    - capistrano
     - ssl
     - email
     - queue
@@ -16,7 +17,6 @@
       become: true
     - memcached
     - timezone
-    # - capistrano
 
 - name: Check system
   hosts: all

--- a/group_vars/all
+++ b/group_vars/all
@@ -3,6 +3,9 @@ app_name: consul
 server_hostname: "{{ ansible_default_ipv4.address }}"
 secret_key_base: "change_me"
 
+#Capistrano
+repo_url: https://github.com/consul/consul.git
+
 # Server Timzone + Locale
 timezone: Europe/Madrid
 locale: en_US.UTF-8
@@ -12,6 +15,7 @@ env: production
 root_access: true
 deploy_user: deploy
 deploy_dir: "/home/{{ deploy_user }}/"
+deploy_path: "/home/{{ deploy_user }}/{{ app_name }}"
 deploy_password: test
 deploy_app_name: test
 deploy_server_hostname: 127.0.0.1

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -23,7 +23,7 @@
 
 - name: Cat authorized keys
   slurp:
-    src: "/home/{{ deploy_user }}/.ssh/authorized_keys"
+    src: "/home/deploy/.ssh/authorized_keys"
   register: deploy_authorized_keys
   ignore_errors: yes
 

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -5,7 +5,7 @@
   register: local_ssh_key  
 
 - name: Generate local public ssh key
-  become_user: {{ deploy_user }}
+  become_user: "{{ deploy_user }}"
   command: ssh-keygen -t rsa -N "" -f /home/{{ deploy_user }}/.ssh/id_rsa USER={{ deploy_user }}
   when: local_ssh_key.stat.exists == False
   args:

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -1,7 +1,36 @@
 ---
-- include_role:
-    name: galaxy/geerlingguy.nginx
+- name: Check for local ssh key
+  stat:
+    path: "/home/{{ deploy_user }}/.ssh/id_rsa.pub"
+  register: local_ssh_key  
 
+- name: Generate local public ssh key
+  command: ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+  when: local_ssh_key.stat.exists == False
+
+- name: Get local ssh key
+  slurp:
+    src: "/home/{{ deploy_user }}/.ssh/id_rsa.pub"
+  register: local_ssh_key
+
+- debug: msg="{{ local_ssh_key['content'] | b64decode }}"
+
+- name: Install local ssh key
+  authorized_key:
+    user: "{{ deploy_user }}"
+    key: "{{ local_ssh_key['content'] | b64decode }}"
+
+- name: Restart ssh
+  become: true
+  service: name=sshd state=restarted
+
+- name: Copy deploy-secrets.yml to deploy directory
+  template:
+    src: "{{ playbook_dir }}/roles/capistrano/templates/deploy-secrets.yml"
+    dest: "/home/{{ deploy_user }}/{{ app_name }}/config/deploy-secrets.yml"
+    owner: "{{ deploy_user }}"
+    group: wheel
+    
 - name: Creates shared folder
   file:
     path: /home/{{ deploy_user }}/consul/shared
@@ -46,7 +75,7 @@
 - name: Copy delayed jobs configuration to shared folder
   command: cp /home/{{ deploy_user }}/consul/config/initializers/delayed_job_config.rb /home/{{ deploy_user }}/consul/shared/config/initializers/delayed_job_config.rb
 
-- name: Copy unicorn.rb template for capistrano to shared folder
+- name: Copy unicorn.rb template to shared folder
   template:
     src: "{{ playbook_dir }}/roles/capistrano/templates/unicorn.rb"
     dest: "/home/{{ deploy_user }}/consul/shared/config/unicorn.rb"
@@ -65,16 +94,13 @@
     - "sockets"
     - "log"
 
-- name: Update Nginx template for capistrano
-  become: true
-  become_method: sudo
-  template:
-    src: "{{ playbook_dir }}/roles/capistrano/templates/consul_vhost.conf"
-    dest: /etc/nginx/sites-enabled/default
-    owner: "{{ deploy_user }}"
-    group: wheel
-  notify: restart nginx
+#ToDo use environment variable
+- name: Deploy CONSUL to localhost (this may take a few minutes)
+  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && /home/{{ deploy_user }}/.rvm/gems/ruby-{{ ruby_version }}/bin/cap production deploy"
+  args:
+    chdir: /home/{{ deploy_user }}/{{ app_name }}
+    executable: /bin/bash
 
-- name: Restart nginx
-  become: true
-  service: name=nginx state=restarted
+#ToDo
+# Remove duplicate files in home/deploy/consul/
+# Better yet... clone consul to /tmp and them delete /tmp

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -8,21 +8,21 @@
   command: ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
   when: local_ssh_key.stat.exists == False
 
-- name: Get local ssh key
-  slurp:
-    src: "/home/{{ deploy_user }}/.ssh/id_rsa.pub"
-  register: local_ssh_key
-  ignore_errors: yes
-
-- debug: msg="{{ local_ssh_key['content'] | b64decode }}"
-
-- name: Get local ssh key
+- name: Get local travis ssh key
   slurp:
     src: "/home/travis/.ssh/id_rsa.pub"
   register: local_travis_ssh_key
   ignore_errors: yes
 
 - debug: msg="{{ local_travis_ssh_key['content'] | b64decode }}"
+
+- name: Get local deploy ssh key
+  slurp:
+    src: "/home/{{ deploy_user }}/.ssh/id_rsa.pub"
+  register: local_ssh_key
+  ignore_errors: yes
+
+- debug: msg="{{ local_ssh_key['content'] | b64decode }}"
 
 - name: Install local ssh key
   authorized_key:

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -24,9 +24,11 @@
 - name: Cat authorized keys
   slurp:
     src: "/home/{{ deploy_user }}/.ssh/authorized_keys"
-  register: local_ssh_key
+  register: deploy_authorized_keys
   ignore_errors: yes
-  
+
+- debug: msg="{{ deploy_authorized_keys['content'] | b64decode }}"
+
 - name: Restart ssh
   become: true
   service: name=sshd state=restarted

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -8,14 +8,6 @@
   command: ssh-keygen -t rsa -N "" -f /home/{{ deploy_user }}/.ssh/id_rsa
   when: local_ssh_key.stat.exists == False
 
-- name: Get local travis ssh key
-  slurp:
-    src: "/home/travis/.ssh/id_rsa.pub"
-  register: local_travis_ssh_key
-  ignore_errors: yes
-
-- debug: msg="{{ local_travis_ssh_key['content'] | b64decode }}"
-
 - name: Get local deploy ssh key
   slurp:
     src: "/home/{{ deploy_user }}/.ssh/id_rsa.pub"
@@ -29,6 +21,12 @@
     user: "{{ deploy_user }}"
     key: "{{ local_ssh_key['content'] | b64decode }}"
 
+- name: Cat authorized keys
+  slurp:
+    src: "/home/{{ deploy_user }}/.ssh/authorized_keys"
+  register: local_ssh_key
+  ignore_errors: yes
+  
 - name: Restart ssh
   become: true
   service: name=sshd state=restarted

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -5,7 +5,7 @@
   register: local_ssh_key  
 
 - name: Generate local public ssh key
-  become: true
+  become_user: {{ deploy_user }}
   command: ssh-keygen -t rsa -N "" -f /home/{{ deploy_user }}/.ssh/id_rsa
   when: local_ssh_key.stat.exists == False
   args:

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -6,7 +6,7 @@
 
 - name: Generate local public ssh key
   become_user: {{ deploy_user }}
-  command: ssh-keygen -t rsa -N "" -f /home/{{ deploy_user }}/.ssh/id_rsa
+  command: ssh-keygen -t rsa -N "" -f /home/{{ deploy_user }}/.ssh/id_rsa USER={{ deploy_user }}
   when: local_ssh_key.stat.exists == False
   args:
     executable: /bin/bash

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -8,6 +8,8 @@
   become: true
   command: ssh-keygen -t rsa -N "" -f /home/{{ deploy_user }}/.ssh/id_rsa
   when: local_ssh_key.stat.exists == False
+  args:
+    executable: /bin/bash
 
 - name: Get local deploy ssh key
   slurp:

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Get local ssh key
   slurp:
-    src: "/home/travis/.ssh/id_rsa.pub"
+    src: "/home/{{ deploy_user }}/.ssh/id_rsa.pub"
   register: local_ssh_key
 
 - debug: msg="{{ local_ssh_key['content'] | b64decode }}"

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -5,7 +5,7 @@
   register: local_ssh_key  
 
 - name: Generate local public ssh key
-  command: ssh-keygen -t rsa -N "" -f ~/.ssh/id_rsa
+  command: ssh-keygen -t rsa -N "" -f /home/{{ deploy_user }}/.ssh/id_rsa
   when: local_ssh_key.stat.exists == False
 
 - name: Get local travis ssh key

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -10,7 +10,7 @@
 
 - name: Get local ssh key
   slurp:
-    src: "/home/{{ deploy_user }}/.ssh/id_rsa.pub"
+    src: "/home/travis/.ssh/id_rsa.pub"
   register: local_ssh_key
 
 - debug: msg="{{ local_ssh_key['content'] | b64decode }}"

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -5,6 +5,7 @@
   register: local_ssh_key  
 
 - name: Generate local public ssh key
+  become: true
   command: ssh-keygen -t rsa -N "" -f /home/{{ deploy_user }}/.ssh/id_rsa
   when: local_ssh_key.stat.exists == False
 

--- a/roles/capistrano/tasks/main.yml
+++ b/roles/capistrano/tasks/main.yml
@@ -12,8 +12,17 @@
   slurp:
     src: "/home/{{ deploy_user }}/.ssh/id_rsa.pub"
   register: local_ssh_key
+  ignore_errors: yes
 
 - debug: msg="{{ local_ssh_key['content'] | b64decode }}"
+
+- name: Get local ssh key
+  slurp:
+    src: "/home/travis/.ssh/id_rsa.pub"
+  register: local_travis_ssh_key
+  ignore_errors: yes
+
+- debug: msg="{{ local_travis_ssh_key['content'] | b64decode }}"
 
 - name: Install local ssh key
   authorized_key:

--- a/roles/capistrano/templates/deploy-secrets.yml
+++ b/roles/capistrano/templates/deploy-secrets.yml
@@ -1,7 +1,7 @@
 production:
   deploy_to: {{ deploy_path }}
   ssh_port: "22"
-  server1: "{{ server_hostname }}"
+  server1: "travis.dev"
   db_server: "localhost"
   user: "travis"
   server_name: "{{ server_hostname }}" #ToDo change for domain

--- a/roles/capistrano/templates/deploy-secrets.yml
+++ b/roles/capistrano/templates/deploy-secrets.yml
@@ -3,7 +3,7 @@ production:
   ssh_port: "22"
   server1: "travis.dev"
   db_server: "localhost"
-  user: "travis"
+  user: "{{ deploy_user }}"
   server_name: "{{ server_hostname }}" #ToDo change for domain
   full_app_name: "{{ app_name }}"
 

--- a/roles/capistrano/templates/deploy-secrets.yml
+++ b/roles/capistrano/templates/deploy-secrets.yml
@@ -1,7 +1,7 @@
 production:
   deploy_to: {{ deploy_path }}
   ssh_port: "22"
-  server1: "{{ server_hostname }}"
+  server1: "localhost"
   db_server: "localhost"
   user: "{{ deploy_user }}"
   server_name: "{{ server_hostname }}" #ToDo change for domain

--- a/roles/capistrano/templates/deploy-secrets.yml
+++ b/roles/capistrano/templates/deploy-secrets.yml
@@ -3,7 +3,7 @@ production:
   ssh_port: "22"
   server1: "{{ server_hostname }}"
   db_server: "localhost"
-  user: "{{ deploy_user }}"
+  user: "travis"
   server_name: "{{ server_hostname }}" #ToDo change for domain
   full_app_name: "{{ app_name }}"
 

--- a/roles/capistrano/templates/deploy-secrets.yml
+++ b/roles/capistrano/templates/deploy-secrets.yml
@@ -1,7 +1,7 @@
 production:
   deploy_to: {{ deploy_path }}
   ssh_port: "22"
-  server1: "travis.dev"
+  server1: "{{ server_hostname }}"
   db_server: "localhost"
   user: "{{ deploy_user }}"
   server_name: "{{ server_hostname }}" #ToDo change for domain

--- a/roles/capistrano/templates/deploy-secrets.yml
+++ b/roles/capistrano/templates/deploy-secrets.yml
@@ -1,0 +1,10 @@
+production:
+  deploy_to: {{ deploy_path }}
+  ssh_port: "22"
+  server1: "localhost"
+  db_server: "localhost"
+  user: "{{ deploy_user }}"
+  server_name: "{{ server_hostname }}" #ToDo change for domain
+  full_app_name: "{{ app_name }}"
+
+#ToDo add staging configuration

--- a/roles/capistrano/templates/deploy-secrets.yml
+++ b/roles/capistrano/templates/deploy-secrets.yml
@@ -1,7 +1,7 @@
 production:
   deploy_to: {{ deploy_path }}
   ssh_port: "22"
-  server1: "localhost"
+  server1: "{{ server_hostname }}"
   db_server: "localhost"
   user: "{{ deploy_user }}"
   server_name: "{{ server_hostname }}" #ToDo change for domain

--- a/roles/capistrano/templates/deploy.rb
+++ b/roles/capistrano/templates/deploy.rb
@@ -1,0 +1,74 @@
+### Difference with CONSUL
+set :branch, :capistrano
+###
+
+# config valid only for current version of Capistrano
+lock "~> 3.10.1"
+
+def deploysecret(key)
+  @deploy_secrets_yml ||= YAML.load_file("config/deploy-secrets.yml")[fetch(:stage).to_s]
+  @deploy_secrets_yml.fetch(key.to_s, "undefined")
+end
+
+set :rails_env, fetch(:stage)
+set :rvm1_ruby_version, "2.3.2"
+
+set :application, "consul"
+set :full_app_name, deploysecret(:full_app_name)
+
+set :server_name, deploysecret(:server_name)
+set :repo_url, "https://github.com/consul/consul.git"
+
+set :revision, `git rev-parse --short #{fetch(:branch)}`.strip
+
+set :log_level, :info
+set :pty, true
+set :use_sudo, false
+
+set :linked_files, %w{config/database.yml config/secrets.yml config/unicorn.rb config/environments/production.rb}
+set :linked_dirs, %w{log tmp public/system public/assets public/ckeditor_assets}
+
+set :keep_releases, 5
+
+set :local_user, ENV["USER"]
+
+set :delayed_job_workers, 2
+set :delayed_job_roles, :background
+
+set(:config_files, %w(
+  log_rotation
+  database.yml
+  secrets.yml
+  unicorn.rb
+))
+
+set :whenever_roles, -> { :app }
+
+namespace :deploy do
+  #before :starting, "rvm1:install:rvm"  # install/update RVM
+  #before :starting, "rvm1:install:ruby" # install Ruby and create gemset
+  #before :starting, "install_bundler_gem" # install bundler gem
+
+  after :publishing, "deploy:restart"
+  after :published, "delayed_job:restart"
+  after :published, "refresh_sitemap"
+
+  after :finishing, "deploy:cleanup"
+end
+
+task :install_bundler_gem do
+  on roles(:app) do
+    execute "rvm use #{fetch(:rvm1_ruby_version)}; gem install bundler"
+  end
+end
+
+task :refresh_sitemap do
+  on roles(:app) do
+    within release_path do
+      with rails_env: fetch(:rails_env) do
+        execute :rake, "sitemap:refresh:no_ping"
+      end
+    end
+  end
+end
+

--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -2,10 +2,15 @@
 - include_role:
     name: galaxy/geerlingguy.nginx
 
-- name: Change default template
+- name: Update Nginx template for capistrano
+  become: true
+  become_method: sudo
   template:
-    src: "{{ playbook_dir }}/roles/nginx/templates/consul_vhost.conf"
+    src: "{{ playbook_dir }}/roles/capistrano/templates/consul_vhost.conf"
     dest: /etc/nginx/sites-enabled/default
     owner: "{{ deploy_user }}"
     group: wheel
-  notify: restart nginx
+
+- name: Restart nginx
+  become: true
+  service: name=nginx state=restarted

--- a/roles/nginx/templates/consul_vhost.conf
+++ b/roles/nginx/templates/consul_vhost.conf
@@ -1,20 +1,20 @@
 upstream app {
-	server unix:/home/{{ deploy_user }}/consul/sockets/unicorn.sock;
+  server unix:/home/{{ deploy_user }}/consul/sockets/unicorn.sock;
 }
 
 server {
-	listen 80 default_server;
-	listen [::]:80 default_server;
+  listen 80 default_server;
+  listen [::]:80 default_server;
 
-	root /home/{{ deploy_user }}/consul/public;
+  root /home/{{ deploy_user }}/consul/current/public;
 
-	server_name _;
+  server_name _;
 
-	try_files $uri/index.html $uri @app;
-	location @app {
-		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-		proxy_set_header Host $http_host;
-		proxy_redirect off;
-		proxy_pass http://app;
-	}
+  try_files $uri/index.html $uri @app;
+  location @app {
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header Host $http_host;
+    proxy_redirect off;
+    proxy_pass http://app;
+  }
 }

--- a/roles/rails/tasks/main.yml
+++ b/roles/rails/tasks/main.yml
@@ -9,9 +9,11 @@
     repo: https://github.com/consul/consul.git
     dest: /home/{{ deploy_user }}/consul
     clone: yes
+    version: installer_capistrano
   when: consul_repo.stat.exists == False
 
 - name: Deploy user permissions
+  become: true
   file:
     path: /home/{{ deploy_user }}/consul
     owner: "{{ deploy_user }}"
@@ -58,12 +60,6 @@
 
 - name: Load configuration seeds
   shell: "source /home/{{ deploy_user}}/.rvm/scripts/rvm && bin/rake db:seed RAILS_ENV={{ env }}"
-  args:
-    chdir: /home/{{ deploy_user }}/consul
-    executable: /bin/bash
-
-- name: Precompile assets
-  shell: "source /home/{{ deploy_user }}/.rvm/scripts/rvm && bin/rake assets:precompile RAILS_ENV={{ env }}"
   args:
     chdir: /home/{{ deploy_user }}/consul
     executable: /bin/bash

--- a/roles/ssl/tasks/main.yml
+++ b/roles/ssl/tasks/main.yml
@@ -1,5 +1,5 @@
 - name: Use http instead of https (for now https://github.com/consul/installer/issues/8)
   lineinfile:
-    path: /home/{{ deploy_user }}/consul/config/environments/{{ env }}.rb
+    path: /home/{{ deploy_user }}/consul/current/config/environments/{{ env }}.rb
     regexp: 'force_ssl'
     line: '  config.force_ssl = false'

--- a/roles/unicorn/tasks/main.yml
+++ b/roles/unicorn/tasks/main.yml
@@ -1,30 +1,11 @@
 ---
-- name: Add unicorn.rb
-  template:
-    src: ../templates/unicorn.rb
-    dest: "/home/{{ deploy_user }}/consul/config"
-    owner: "{{ deploy_user }}"
-    group: wheel
-
-- name: Add unicorn files and folders
-  file:
-    path: "/home/{{ deploy_user}}/consul/{{ item }}"
-    state: directory
-    owner: "{{ deploy_user }}"
-    group: wheel
-    mode: 0775
-  with_items:
-    - "pids" 
-    - "sockets" 
-    - "log"
-
 - name: Check that Unicorn is running
   stat:
-    path: "/home/{{ deploy_user }}/consul/pids/unicorn.pid"
+    path: "/home/{{ deploy_user }}/consul/shared/pids/unicorn.pid"
   register: unicorn_process
 
 - name: Get running unicorn process
-  shell: "cat /home/{{ deploy_user }}/consul/pids/unicorn.pid"
+  shell: "cat /home/{{ deploy_user }}/consul/shared/pids/unicorn.pid"
   register: running_process
   when: unicorn_process.stat.exists == True
 
@@ -36,5 +17,5 @@
 - name: Start Unicorn
   shell: "/home/{{ deploy_user}}/.rvm/gems/ruby-2.3.2/wrappers/unicorn -c config/unicorn.rb -E {{ env }} -D"
   args:
-    chdir: /home/{{ deploy_user }}/consul
+    chdir: /home/{{ deploy_user }}/consul/shared/
     

--- a/roles/unicorn/templates/unicorn.rb
+++ b/roles/unicorn/templates/unicorn.rb
@@ -1,5 +1,6 @@
 # set path to the application
-app_dir = "/home/{{ deploy_user}}/consul"
+app_dir = "/home/{{ deploy_user }}/consul/current"
+shared_dir = "/home/{{ deploy_user }}/consul/shared"
 working_directory app_dir
 
 # Set unicorn options
@@ -8,11 +9,11 @@ preload_app true
 timeout 60
 
 # Path for the Unicorn socket
-listen "#{app_dir}/sockets/unicorn.sock", :backlog => 64
+listen "#{shared_dir}/sockets/unicorn.sock", :backlog => 64
 
 # Set path for logging
-stderr_path "#{app_dir}/log/unicorn.stderr.log"
-stdout_path "#{app_dir}/log/unicorn.stdout.log"
+stderr_path "#{shared_dir}/log/unicorn.stderr.log"
+stdout_path "#{shared_dir}/log/unicorn.stdout.log"
 
 # Set proccess id path
-pid "#{app_dir}/pids/unicorn.pid"
+pid "#{shared_dir}/pids/unicorn.pid"


### PR DESCRIPTION
## Context
By default CONSUL is installed at path: `/home/deploy/consul`, without capistrano support for deployments. 

Separately, we have a Capistrano role that installs another instance of CONSUL at `/home/deploy/consul/current`.

This was done to simplify the deployment for basic installation, used mainly for demo purposes. The more complicated Capistrano setup had to be done manually by forks that wanted to do multiple deployments to their production environment.

## Objectives
Unify configurations for a single app, installed using Capistrano, at `/home/deploy/consul/current`. 

## How (commits)
- Run Capistrano script as a default role.
- Configure related roles using the Capistrano's folder structure.
- Remove duplicate configuration files.